### PR TITLE
Dish card style change

### DIFF
--- a/src/app/components/dish-card.tsx
+++ b/src/app/components/dish-card.tsx
@@ -4,34 +4,45 @@ import RoundedButton from "./rounded-button";
 
 interface LocationType {
   name: string;
-  rating: string;
   imagePath: string;
+  dishType: string;
+  isPopular: boolean;
 }
 
-const DishCard: React.FC<LocationType> = ({ name, rating, imagePath }) => {
+const DishCard: React.FC<LocationType> = ({
+  name,
+  imagePath,
+  dishType,
+  isPopular,
+}) => {
   return (
     <Link href={"/details"}>
       <div
         className=" flex items-end h-60 w-48 bg-gray-200 rounded-3xl"
         style={{
-          backgroundImage: `url(${imagePath})`,
+          backgroundImage: `linear-gradient(to bottom, transparent, transparent, black), url(${imagePath})`,
           backgroundSize: "cover",
         }}
       >
-        <div className="p-3 flex items-end justify-between w-full">
-          <div className="flex flex-col gap-2 ">
-            <AttractionTag text={name} />
-            <AttractionTag
-              text={rating}
-              backgroundColor="--accent"
-              textColor="--white"
+        <div className="flex flex-col justify-between p-3 h-full w-full">
+          <div className="flex justify-between w-full text-sm">
+            {dishType && <p className="text-white">{dishType}</p>}
+            {isPopular && (
+              <p className="bg-[--yellow-accent] rounded-full p-1 text-white font-semibold">
+                Popular
+              </p>
+            )}
+          </div>
+          <div className=" flex gap-1 items-end justify-between w-full">
+            <p className="text-white font-montserrat font-semibold leading-5">
+              {name}
+            </p>
+            <RoundedButton
+              imageUrl="/icons/heart-lined.svg"
+              height={24}
+              width={24}
             />
           </div>
-          <RoundedButton
-            imageUrl="/icons/heart-lined.svg"
-            height={24}
-            width={24}
-          />
         </div>
       </div>
     </Link>

--- a/src/app/components/molecules/dishes-carousel.tsx
+++ b/src/app/components/molecules/dishes-carousel.tsx
@@ -3,17 +3,28 @@ import DishCard from "../dish-card";
 
 const exampleDishes = [
   {
-    name: "Pasta",
+    name: "Pasta with Garlic, Scallions, Cauliflower & Breadcrumbs",
     price: "$15",
     imagePath: "/images/food-bowl.jpg",
     id: "1",
+    dishType: "dinner",
+    isPopular: false,
   },
-  { name: "Tacos", price: "$12", imagePath: "/images/food-bowl.jpg", id: "2" },
+  {
+    name: "Tacos",
+    price: "$12",
+    imagePath: "/images/food-bowl.jpg",
+    id: "2",
+    dishType: "side dish",
+    isPopular: true,
+  },
   {
     name: "Fried Rice",
     price: "$20",
     imagePath: "/images/food-bowl.jpg",
     id: "3",
+    dishType: "dinner",
+    isPopular: true,
   },
 ];
 
@@ -26,9 +37,10 @@ const DishesCarousel = () => {
         {exampleDishes.map((dish) => (
           <DishCard
             name={dish.name}
-            rating={dish.price}
             imagePath={dish.imagePath}
             key={dish.id}
+            dishType={dish.dishType}
+            isPopular={dish.isPopular}
           />
         ))}
       </div>

--- a/src/app/components/rounded-button.tsx
+++ b/src/app/components/rounded-button.tsx
@@ -14,7 +14,7 @@ const RoundedButton: React.FC<RoundedButtonInterface> = ({
   return (
     <button
       type="button"
-      className=" bg-white  hover:brightness-90 transition rounded-full p-2"
+      className=" flex-shrink-0 bg-white  hover:brightness-90 transition rounded-full p-1"
     >
       <Image alt="icon image" src={imageUrl} width={width} height={height} />
     </button>


### PR DESCRIPTION
So, i was messing around with the API data on a playground branch and i noticed that most of the dish names kind of that break the card layout, so i had to change the style a bit so that it fits the data a little better.

Before:
![image](https://github.com/Nicog03/recipes-app/assets/87248260/6341640c-55b4-4542-bfbd-0b691a1e927c)

After: 
![image](https://github.com/Nicog03/recipes-app/assets/87248260/3f3d7bca-ffd9-4640-8726-2d15bb7e1194)
