### PR TITLE
React query changes

### DIFF
--- a/src/app/components/molecules/popular-section.tsx
+++ b/src/app/components/molecules/popular-section.tsx
@@ -5,28 +5,21 @@ import Header from "../header-component";
 import DishesCarousel from "./dishes-carousel";
 import { getRandomRecipes } from "../../../../api/api-requests";
 import { useQuery } from "@tanstack/react-query";
-import DishCard from "../dish-card";
 import LoadingCard from "../loading-card";
-import { Island_Moments } from "next/font/google";
 
 const PopularSection = () => {
-  const { data, isLoading, isFetching } = useQuery({
+  const { data, isFetching } = useQuery({
     queryKey: ["random-recipes"],
     queryFn: () => getRandomRecipes(),
-    // staleTime: 10 * 1000,
-    //implement this <---
+    staleTime: 10 * 1000,
     refetchOnWindowFocus: false,
-    //--->
   });
-
-  if (isLoading) console.log("isLoading");
-  if (isFetching) console.log("isFetching");
 
   return (
     <section className="flex flex-col gap-3">
       <div className="flex justify-between">
         <Header text="Popular Dishes" size="small" />
-        <TextButton text="See more" />
+        <TextButton onClick={() => {}} text="See more" />
       </div>
       {isFetching ? <LoadingCard /> : <DishesCarousel recipes={data.recipes} />}
     </section>

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -14,7 +14,7 @@ const AttractionPage = ({ params }: any) => {
   const id = params.id;
 
   const { data, isFetching } = useQuery({
-    queryKey: ["random-recipes"],
+    queryKey: ["recipe"],
     queryFn: () => getRecipe(id),
     refetchOnWindowFocus: false,
   });


### PR DESCRIPTION
I've been noticing while working on some changes locally, that when changing between the pages, sometimes the api data wasn't being displayed, which resulted in an empty component. 

Looking a little bit more into that i found out that both queries made within the popular-section and the homepage had the same `queryKey` value, which ended up in: every time the data was fetched it replaced the old one.

Now, with this branch, i changed the value of the `queryKey` on the popular-section component and set a `staleTime` of 10sec on the homepage data. That means that now, the data will persist for 10sec even if the user changes pages.

I might change those values in the future, but i'm not quite sure yet. Anyways, it'll be something much simpler to manage now.