### PR TITLE
Dish page responsivity

### DIFF
--- a/src/app/components/loading-dish-page.tsx
+++ b/src/app/components/loading-dish-page.tsx
@@ -11,7 +11,7 @@ export default function LoadingDishPage() {
       before:animate-[shimmer_2s_infinite]
       before:bg-gradient-to-r before:from-transparent 
       before:via-white before:to-transparent
-      isolate overflow-hidden"
+      isolate overflow-hidden sm:max-w-3xl mx-auto"
     >
       {/* dish image */}
       <div className="relative -z-10">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <ReactQueryProvider>
-          <div className="sm:text-lg xl:max-w-[1426px] 2xl:max-w-[1632px] mx-auto">
+          <div className="sm:text-lg xl:max-w-[1426px] 2xl:max-w-[1526px] mx-auto">
             {children}
           </div>
         </ReactQueryProvider>

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -23,14 +23,16 @@ const AttractionPage = ({ params }: any) => {
     <LoadingDishPage />
   ) : (
     data && (
-      <div className="p-5 flex flex-col gap-6 h-screen ">
+      <div className="p-5 flex flex-col gap-6 h-screen sm:max-w-3xl sm:mx-auto">
         <LargeAttractionImage imageUrl={data.image} />
-        <DescriptionHeading
-          title={data.title}
-          credits={data.sourceName}
-          sourceUrl={data.sourceUrl}
-        />
-        <DescriptionParagraph description={data.summary} />
+        <div className="flex flex-col gap-6 flex-1">
+          <DescriptionHeading
+            title={data.title}
+            credits={data.sourceName}
+            sourceUrl={data.sourceUrl}
+          />
+          <DescriptionParagraph description={data.summary} />
+        </div>
         <DishInformation
           dairyFree={data.dairyFree}
           readyInMinutes={data.readyInMinutes}


### PR DESCRIPTION
Finally was able to start implementing the responsivity on the whole app. 
The first page to receive the implementation was the **dish page**.

So far, i do think that my implementation is a little bit too simple, i mean... i basically just limit the width of the page, so that the content doesn't seem too stretched.

I tried displaying some of the content side-by-side, but i felt like it, on some recipes, it made the page too short, making it a little weird on a wide screen.

So i settled with just limiting the content horizontally

![image](https://github.com/Nicog03/recipes-app/assets/87248260/c3bfb88c-7e21-4a50-9961-44d9c632c4e4)
